### PR TITLE
feat: disambiguate excludeTools and noCompressTools features

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ Create or edit your JSON configuration file at:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `mcpServers` | array | ✅ | Array of server configurations |
-| `ignoreTools` | string[] | ❌ | Tool name patterns to ignore (supports wildcards) |
+| `excludeTools` | string[] | ❌ | Tool name patterns to exclude from tool list entirely (supports wildcards) |
+| `noCompressTools` | string[] | ❌ | Tool name patterns to never compress - descriptions pass through unchanged (supports wildcards) |
 
 **Server Configuration:**
 | Field | Type | Required | Description |
@@ -288,18 +289,35 @@ Use `${VAR_NAME}` syntax to reference environment variables:
 
 Variables are expanded at runtime from your shell environment.
 
-#### Tool Ignore Patterns
+#### Tool Filtering Patterns
 
-Use the `ignoreTools` field to filter out unwanted tools using wildcard patterns (case-insensitive):
+**Exclude Tools** - Remove tools from the tool list entirely:
+
+Use the `excludeTools` field to filter out unwanted tools using wildcard patterns (case-insensitive):
 
 ```json
 {
   "mcpServers": [...],
-  "ignoreTools": [
-    "github__*",        // Ignore all GitHub tools
-    "*__delete*",       // Ignore all delete operations
-    "filesystem__write_*",  // Ignore filesystem write tools
-    "set_*"             // Ignore management tools starting with set_
+  "excludeTools": [
+    "github__delete_*",     // Exclude all GitHub delete tools
+    "*__experimental*",     // Exclude all experimental tools
+    "filesystem__write_*",  // Exclude filesystem write tools
+    "set_*"                 // Exclude management tools starting with set_
+  ]
+}
+```
+
+**No-Compress Tools** - Keep tools but never compress their descriptions:
+
+Use the `noCompressTools` field to bypass compression for specific tools (descriptions pass through unchanged):
+
+```json
+{
+  "mcpServers": [...],
+  "noCompressTools": [
+    "filesystem__*",        // Never compress filesystem tool descriptions
+    "*__help",              // Never compress help commands
+    "github__search_*"      // Never compress GitHub search tools
   ]
 }
 ```
@@ -309,6 +327,10 @@ Use the `ignoreTools` field to filter out unwanted tools using wildcard patterns
 - `"*__toolPattern*"` - Tools matching pattern from any server
 - `"exact_tool_name"` - Exact tool name match
 
+**Use Cases:**
+- **excludeTools**: Remove dangerous tools, unwanted features, or tools not relevant to your workflow
+- **noCompressTools**: Preserve detailed descriptions for complex tools where compression might lose important information
+
 #### Configuration Aggregation
 
 Both config files are loaded and combined:
@@ -316,13 +338,15 @@ Both config files are loaded and combined:
 1. Load user config (`~/.mcp-compression-proxy/servers.json`)
 2. Load project config (`./servers.json`)
 3. Aggregate servers from both configs
-4. Aggregate ignore patterns from both configs
-5. Apply ignore patterns to filter tools
+4. Aggregate exclude and noCompress patterns from both configs
+5. Apply exclude patterns to filter tools
+6. Apply noCompress patterns to bypass compression
 
 This allows:
 - Personal defaults in user config
 - Team/project-specific servers in project config
-- Fine-grained tool filtering with ignore patterns
+- Fine-grained tool filtering with exclude patterns
+- Selective compression bypass with noCompress patterns
 
 ### Environment Variables
 

--- a/servers.json.example
+++ b/servers.json.example
@@ -16,8 +16,11 @@
       "enabled": true
     }
   ],
-  "ignoreTools": [
+  "excludeTools": [
     "github__delete_*",
     "*__experimental*"
+  ],
+  "noCompressTools": [
+    "filesystem__*"
   ]
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -127,19 +127,21 @@ export function matchesIgnorePattern(toolName: string, patterns: string[]): bool
 
 export type ConfigResult = {
   servers: MCPServerConfig[];
-  ignorePatterns: string[];
+  excludePatterns: string[];
+  noCompressPatterns: string[];
 } | null;
 
 /**
  * Load and aggregate server configuration from JSON files
- * 1. Load user-level config and collect ignore patterns
+ * 1. Load user-level config and collect patterns
  * 2. Load project-level config and append servers
- * 3. Aggregate ignore patterns from both configs
+ * 3. Aggregate exclude and noCompress patterns from both configs
  */
 export function loadJSONServers(): ConfigResult {
   const paths = getConfigPaths();
   let aggregatedServers: MCPServerConfig[] = [];
-  let aggregatedIgnorePatterns: string[] = [];
+  let aggregatedExcludePatterns: string[] = [];
+  let aggregatedNoCompressPatterns: string[] = [];
   let hasAnyConfig = false;
 
   // Step 1: Load user-level config
@@ -149,8 +151,11 @@ export function loadJSONServers(): ConfigResult {
     console.log(`[Config] Loaded user-level configuration from: ${paths.user}`);
 
     aggregatedServers = [...userConfig.mcpServers];
-    if (userConfig.ignoreTools) {
-      aggregatedIgnorePatterns = [...userConfig.ignoreTools];
+    if (userConfig.excludeTools) {
+      aggregatedExcludePatterns = [...userConfig.excludeTools];
+    }
+    if (userConfig.noCompressTools) {
+      aggregatedNoCompressPatterns = [...userConfig.noCompressTools];
     }
   }
 
@@ -163,9 +168,14 @@ export function loadJSONServers(): ConfigResult {
     // Append project servers
     aggregatedServers = [...aggregatedServers, ...projectConfig.mcpServers];
 
-    // Append project ignore patterns
-    if (projectConfig.ignoreTools) {
-      aggregatedIgnorePatterns = [...aggregatedIgnorePatterns, ...projectConfig.ignoreTools];
+    // Append project exclude patterns
+    if (projectConfig.excludeTools) {
+      aggregatedExcludePatterns = [...aggregatedExcludePatterns, ...projectConfig.excludeTools];
+    }
+
+    // Append project noCompress patterns
+    if (projectConfig.noCompressTools) {
+      aggregatedNoCompressPatterns = [...aggregatedNoCompressPatterns, ...projectConfig.noCompressTools];
     }
   }
 
@@ -179,16 +189,22 @@ export function loadJSONServers(): ConfigResult {
     console.warn(`[Config] Found ${disabled.length} disabled server(s): ${disabled.map(s => s.name).join(', ')}`);
   }
 
-  // Log ignore patterns
-  if (aggregatedIgnorePatterns.length > 0) {
-    console.log(`[Config] Tool ignore patterns: ${aggregatedIgnorePatterns.join(', ')}`);
+  // Log exclude patterns
+  if (aggregatedExcludePatterns.length > 0) {
+    console.log(`[Config] Tool exclude patterns: ${aggregatedExcludePatterns.join(', ')}`);
+  }
+
+  // Log noCompress patterns
+  if (aggregatedNoCompressPatterns.length > 0) {
+    console.log(`[Config] Tool noCompress patterns: ${aggregatedNoCompressPatterns.join(', ')}`);
   }
 
   console.log(`[Config] Total servers after aggregation: ${aggregatedServers.length}`);
 
   return {
     servers: aggregatedServers,
-    ignorePatterns: aggregatedIgnorePatterns,
+    excludePatterns: aggregatedExcludePatterns,
+    noCompressPatterns: aggregatedNoCompressPatterns,
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -43,9 +43,16 @@ export const serverConfigSchema = {
         additionalProperties: false,
       },
     },
-    ignoreTools: {
+    excludeTools: {
       type: 'array',
-      description: 'Tool name patterns to ignore/exclude (supports wildcards, case-insensitive). Examples: "server__*" (all tools from server), "*__set*" (tools with "set" in name)',
+      description: 'Tool name patterns to exclude from tool list entirely (supports wildcards, case-insensitive). Examples: "server__*" (all tools from server), "*__set*" (tools with "set" in name)',
+      items: {
+        type: 'string',
+      },
+    },
+    noCompressTools: {
+      type: 'array',
+      description: 'Tool name patterns to never compress - descriptions pass through unchanged (supports wildcards, case-insensitive). Tools still appear in list but are never cached/compressed.',
       items: {
         type: 'string',
       },
@@ -63,5 +70,6 @@ export type ServerConfigJSON = {
     env?: Record<string, string>;
     enabled?: boolean;
   }>;
-  ignoreTools?: string[];
+  excludeTools?: string[];
+  noCompressTools?: string[];
 };

--- a/src/config/servers.ts
+++ b/src/config/servers.ts
@@ -48,9 +48,17 @@ export function getEnabledServers(): MCPServerConfig[] {
 }
 
 /**
- * Get tool ignore patterns from configuration
+ * Get tool exclude patterns from configuration
  */
-export function getIgnorePatterns(): string[] {
+export function getExcludePatterns(): string[] {
   const configResult = loadJSONServers();
-  return configResult?.ignorePatterns || [];
+  return configResult?.excludePatterns || [];
+}
+
+/**
+ * Get tool noCompress patterns from configuration
+ */
+export function getNoCompressPatterns(): string[] {
+  const configResult = loadJSONServers();
+  return configResult?.noCompressPatterns || [];
 }


### PR DESCRIPTION
Renamed and separated two distinct features:
1. excludeTools: Remove tools from tool list entirely
2. noCompressTools: Keep tools but bypass compression (pass-through)

Changes:
- Renamed ignoreTools -> excludeTools for clarity
- Added noCompressTools feature for compression bypass
- Updated CompressionCache to respect noCompress patterns
- Modified configuration schema and loader to support both
- Updated all tests with new naming and noCompress tests
- Enhanced documentation with clear use cases for each feature

Both features support:
- Wildcard patterns (*, case-insensitive)
- Aggregation from user and project configs
- Pattern matching via matchesIgnorePattern()

Use cases:
- excludeTools: Remove dangerous/unwanted tools
- noCompressTools: Preserve detailed descriptions where needed