### PR TITLE
feat: add stats management tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Restart your MCP client (e.g., Claude Desktop) to load the new configuration. Th
 | `cache_compressed_tools` | Save compressed descriptions to cache (batch processing) |
 | `expand_tool` | Expand a tool to show full description (session-specific) |
 | `collapse_tool` | Collapse tool back to compressed description |
+| `stats` | Return JSON summary of coverage, cache health, sessions, and per-server tool counts |
+
+Use `stats` from your client (e.g., `mcp-compression-proxy__stats`) to sanity-check coverage. Optional inputs: `serverName` to scope to one backend and `detailLevel` (`summary` or `full`, default `summary`). The response includes coverage %, estimated token savings, cache state, active sessions, and per-server tool counts (respecting your exclude patterns).
+| `stats` | Return JSON summary of coverage, cache health, sessions, and per-server tool counts |
 
 ### Workflow Example
 

--- a/src/services/stats-service.ts
+++ b/src/services/stats-service.ts
@@ -1,0 +1,279 @@
+import type { Logger } from 'pino';
+import type { MCPClientManager } from '../mcp/client-manager.js';
+import type { CompressionCache } from './compression-cache.js';
+import type { SessionManager } from './session-manager.js';
+import type { ConfigResult } from '../config/loader.js';
+import { matchesIgnorePattern, loadJSONServers } from '../config/loader.js';
+
+type DetailLevel = 'summary' | 'full';
+
+type ServerToolStats = {
+  name: string;
+  connected: boolean;
+  error?: string;
+  toolsTotal: number;
+  toolsCompressed: number;
+  toolsUncompressed: number;
+  toolsExcluded: number;
+  coveragePercent: number;
+  originalChars: number;
+  compressedChars: number;
+  estimatedTokensSaved: number;
+};
+
+export type StatsPayload = {
+  summary: {
+    serversConfigured: number;
+    serversConnected: number;
+    serversWithErrors: number;
+    toolsTotal: number;
+    toolsCompressed: number;
+    toolsUncompressed: number;
+    coveragePercent: number;
+    originalChars: number;
+    compressedChars: number;
+    estimatedTokensSaved: number;
+  };
+  servers: ServerToolStats[];
+  compression: {
+    cacheEntries: number;
+    cacheFilePath?: string;
+    cacheSizeBytes: number;
+    missingOriginals: number;
+    latestCompressedAt?: string;
+    totalOriginalChars: number;
+    totalCompressedChars: number;
+    estimatedTokensSaved: number;
+  };
+  sessions: {
+    activeSessions: number;
+    expandedToolsTotal: number;
+    sessions?: Array<{ sessionId: string; expandedToolsCount: number }>;
+  };
+  config: {
+    excludePatterns: string[];
+    noCompressPatterns: string[];
+  };
+};
+
+export class StatsService {
+  private logger: Logger;
+  private clientManager: MCPClientManager;
+  private compressionCache: CompressionCache;
+  private sessionManager: SessionManager;
+  private configLoader: () => ConfigResult;
+
+  constructor(
+    logger: Logger,
+    clientManager: MCPClientManager,
+    compressionCache: CompressionCache,
+    sessionManager: SessionManager,
+    configLoader: () => ConfigResult = loadJSONServers
+  ) {
+    this.logger = logger;
+    this.clientManager = clientManager;
+    this.compressionCache = compressionCache;
+    this.sessionManager = sessionManager;
+    this.configLoader = configLoader;
+  }
+
+  async getStats(options?: {
+    detailLevel?: DetailLevel;
+    serverName?: string;
+  }): Promise<StatsPayload> {
+    const detailLevel: DetailLevel = options?.detailLevel === 'full' ? 'full' : 'summary';
+    const serverFilter = options?.serverName;
+
+    const config = this.configLoader() || {
+      servers: [],
+      excludePatterns: [],
+      noCompressPatterns: [],
+    };
+
+    const excludePatterns = config.excludePatterns || [];
+    const noCompressPatterns = config.noCompressPatterns || [];
+
+    const serverStatuses = this.clientManager.getServerStatuses();
+    const connectedClients = this.clientManager.getConnectedClients();
+
+    const connectedClientMap = new Map(connectedClients.map((c) => [c.name, c.client]));
+
+    const targetStatuses = serverFilter
+      ? serverStatuses.filter((s) => s.name === serverFilter)
+      : serverStatuses;
+
+    if (serverFilter && targetStatuses.length === 0) {
+      throw new Error(`Server '${serverFilter}' is not configured or not initialized`);
+    }
+
+    const serverStats: ServerToolStats[] = [];
+
+    for (const status of targetStatuses) {
+      if (!status.connected) {
+        serverStats.push({
+          name: status.name,
+          connected: false,
+          error: status.lastError || 'Not connected',
+          toolsTotal: 0,
+          toolsCompressed: 0,
+          toolsUncompressed: 0,
+          toolsExcluded: 0,
+          coveragePercent: 0,
+          originalChars: 0,
+          compressedChars: 0,
+          estimatedTokensSaved: 0,
+        });
+        continue;
+      }
+
+      const client = connectedClientMap.get(status.name);
+      if (!client) {
+        serverStats.push({
+          name: status.name,
+          connected: false,
+          error: 'Client not available',
+          toolsTotal: 0,
+          toolsCompressed: 0,
+          toolsUncompressed: 0,
+          toolsExcluded: 0,
+          coveragePercent: 0,
+          originalChars: 0,
+          compressedChars: 0,
+          estimatedTokensSaved: 0,
+        });
+        continue;
+      }
+
+      try {
+        const result = await client.listTools();
+        const filtered = result.tools.filter(
+          (tool) => !matchesIgnorePattern(`${status.name}__${tool.name}`, excludePatterns)
+        );
+        const excludedCount = result.tools.length - filtered.length;
+
+        let toolsCompressed = 0;
+        let originalChars = 0;
+        let compressedChars = 0;
+
+        for (const tool of filtered) {
+          const original = this.compressionCache.getOriginalDescription(status.name, tool.name) ??
+            tool.description ??
+            '';
+          const hasCompression = this.compressionCache.hasCompressed(status.name, tool.name);
+          const compressed =
+            this.compressionCache.getCompressedDescription(status.name, tool.name) ??
+            (hasCompression ? '' : tool.description ?? '');
+
+          if (hasCompression) {
+            toolsCompressed += 1;
+          }
+
+          originalChars += original.length;
+          compressedChars += compressed.length;
+        }
+
+        const toolsTotal = filtered.length;
+        const toolsUncompressed = Math.max(toolsTotal - toolsCompressed, 0);
+        const estimatedTokensSaved = this.calculateTokensSaved(originalChars, compressedChars);
+
+        serverStats.push({
+          name: status.name,
+          connected: true,
+          toolsTotal,
+          toolsCompressed,
+          toolsUncompressed,
+          toolsExcluded: excludedCount,
+          coveragePercent: this.coverage(toolsCompressed, toolsTotal),
+          originalChars,
+          compressedChars,
+          estimatedTokensSaved,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn({ server: status.name, error: message }, 'Failed to list tools for stats');
+
+        serverStats.push({
+          name: status.name,
+          connected: true,
+          error: message,
+          toolsTotal: 0,
+          toolsCompressed: 0,
+          toolsUncompressed: 0,
+          toolsExcluded: 0,
+          coveragePercent: 0,
+          originalChars: 0,
+          compressedChars: 0,
+          estimatedTokensSaved: 0,
+        });
+      }
+    }
+
+    const aggregateTotalTools = serverStats.reduce((sum, s) => sum + s.toolsTotal, 0);
+    const aggregateCompressed = serverStats.reduce((sum, s) => sum + s.toolsCompressed, 0);
+    const aggregateOriginalChars = serverStats.reduce((sum, s) => sum + s.originalChars, 0);
+    const aggregateCompressedChars = serverStats.reduce((sum, s) => sum + s.compressedChars, 0);
+
+    const cacheMetrics = this.compressionCache.getCacheMetrics();
+
+    const sessions = this.sessionManager.getAllSessions();
+
+    const payload: StatsPayload = {
+      summary: {
+        serversConfigured: config.servers?.length || serverStatuses.length,
+        serversConnected: serverStatuses.filter((s) => s.connected).length,
+        serversWithErrors: serverStatuses.filter((s) => !s.connected || s.lastError).length,
+        toolsTotal: aggregateTotalTools,
+        toolsCompressed: aggregateCompressed,
+        toolsUncompressed: Math.max(aggregateTotalTools - aggregateCompressed, 0),
+        coveragePercent: this.coverage(aggregateCompressed, aggregateTotalTools),
+        originalChars: aggregateOriginalChars,
+        compressedChars: aggregateCompressedChars,
+        estimatedTokensSaved: this.calculateTokensSaved(
+          aggregateOriginalChars,
+          aggregateCompressedChars
+        ),
+      },
+      servers: serverStats,
+      compression: {
+        cacheEntries: cacheMetrics.totalCached,
+        cacheFilePath: this.compressionCache.getCacheFilePath(),
+        cacheSizeBytes: cacheMetrics.cacheSizeBytes,
+        missingOriginals: cacheMetrics.missingOriginals,
+        latestCompressedAt: cacheMetrics.latestCompressedAt,
+        totalOriginalChars: cacheMetrics.totalOriginalChars,
+        totalCompressedChars: cacheMetrics.totalCompressedChars,
+        estimatedTokensSaved: this.calculateTokensSaved(
+          cacheMetrics.totalOriginalChars,
+          cacheMetrics.totalCompressedChars
+        ),
+      },
+      sessions: {
+        activeSessions: sessions.length,
+        expandedToolsTotal: sessions.reduce((sum, session) => sum + session.expandedTools.length, 0),
+        sessions:
+          detailLevel === 'full'
+            ? sessions.map((session) => ({
+                sessionId: session.sessionId,
+                expandedToolsCount: session.expandedTools.length,
+              }))
+            : undefined,
+      },
+      config: {
+        excludePatterns,
+        noCompressPatterns,
+      },
+    };
+
+    return payload;
+  }
+
+  private coverage(done: number, total: number): number {
+    if (!total) return 0;
+    return Math.round((done / total) * 1000) / 10; // one decimal place
+  }
+
+  private calculateTokensSaved(originalChars: number, compressedChars: number): number {
+    const savedChars = Math.max(originalChars - compressedChars, 0);
+    return Math.round(savedChars / 4); // rough char->token estimate
+  }
+}

--- a/src/types/compression.ts
+++ b/src/types/compression.ts
@@ -23,3 +23,22 @@ export interface SessionInfo {
   lastAccessedAt: string;
   expandedTools: string[];
 }
+
+export interface CacheMetrics {
+  totalCached: number;
+  totalOriginalChars: number;
+  totalCompressedChars: number;
+  missingOriginals: number;
+  latestCompressedAt?: string;
+  cacheSizeBytes: number;
+  perServer: Record<
+    string,
+    {
+      cached: number;
+      totalOriginalChars: number;
+      totalCompressedChars: number;
+      missingOriginals: number;
+      latestCompressedAt?: string;
+    }
+  >;
+}

--- a/tests/unit/compression-cache.test.ts
+++ b/tests/unit/compression-cache.test.ts
@@ -187,6 +187,27 @@ describe('CompressionCache', () => {
     });
   });
 
+  describe('getCacheMetrics', () => {
+    it('should compute metrics for cached entries', () => {
+      cache.saveCompressed('server1', 'tool1', 'compressed', 'original');
+      cache.saveCompressed('server1', 'tool2', 'compressed-two');
+      cache.saveCompressed('server2', 'tool3', 'c3', 'orig3');
+
+      const metrics = cache.getCacheMetrics();
+
+      expect(metrics.totalCached).toBe(3);
+      expect(metrics.totalCompressedChars).toBe(
+        'compressed'.length + 'compressed-two'.length + 'c3'.length
+      );
+      expect(metrics.totalOriginalChars).toBe('original'.length + 0 + 'orig3'.length);
+      expect(metrics.missingOriginals).toBe(1);
+      expect(metrics.perServer.server1.cached).toBe(2);
+      expect(metrics.perServer.server2.cached).toBe(1);
+      expect(metrics.cacheSizeBytes).toBeGreaterThan(0);
+      expect(metrics.latestCompressedAt).toBeDefined();
+    });
+  });
+
   describe('clear', () => {
     it('should clear all cached descriptions', () => {
       cache.saveCompressed('server1', 'tool1', 'compressed1');

--- a/tests/unit/stats-service.test.ts
+++ b/tests/unit/stats-service.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import type { Logger } from 'pino';
+import type { MCPClientManager } from '../../src/mcp/client-manager.js';
+import type { CompressionPersistence } from '../../src/services/compression-persistence.js';
+import { CompressionCache } from '../../src/services/compression-cache.js';
+import { SessionManager } from '../../src/services/session-manager.js';
+import { StatsService } from '../../src/services/stats-service.js';
+
+describe('StatsService', () => {
+  let mockLogger: Logger;
+  let mockClientManager: jest.Mocked<MCPClientManager>;
+  let mockPersistence: jest.Mocked<CompressionPersistence>;
+  let cache: CompressionCache;
+  let sessionManager: SessionManager;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as Logger;
+
+    mockPersistence = {
+      load: jest.fn(),
+      save: jest.fn(),
+      clear: jest.fn(),
+      getCacheFilePath: jest.fn().mockReturnValue('/tmp/cache.json'),
+    } as unknown as jest.Mocked<CompressionPersistence>;
+
+    cache = new CompressionCache(mockLogger, mockPersistence);
+    sessionManager = new SessionManager(mockLogger);
+
+    mockClientManager = {
+      getConnectedClients: jest.fn(),
+      getServerStatuses: jest.fn(),
+      initializeServers: jest.fn(),
+      disconnectAll: jest.fn(),
+      getClient: jest.fn(),
+      hasConnectedServers: jest.fn(),
+    } as unknown as jest.Mocked<MCPClientManager>;
+  });
+
+  afterEach(() => {
+    sessionManager.destroy();
+  });
+
+  it('returns summary and full stats including coverage, cache, sessions, and config', async () => {
+    const listTools = async () => ({
+      tools: [
+        { name: 'read', description: 'read original' },
+        { name: 'write', description: 'write original' },
+        { name: 'skip_me', description: 'skip original' },
+      ],
+    });
+
+    mockClientManager.getConnectedClients.mockReturnValue([
+      { name: 'serverA', client: { listTools } as any },
+    ]);
+    mockClientManager.getServerStatuses.mockReturnValue([
+      { name: 'serverA', connected: true },
+    ]);
+
+    // One compressed tool with original
+    cache.saveCompressed('serverA', 'write', 'write cmp', 'write original');
+
+    // Active session with an expanded tool
+    const sessionId = sessionManager.createSession();
+    sessionManager.expandTool(sessionId, 'serverA', 'read');
+
+    const configLoader = () => ({
+      servers: [{ name: 'serverA', command: 'cmd' }],
+      excludePatterns: ['serverA__skip_*'],
+      noCompressPatterns: ['serverA__no_compress_*'],
+      defaultTimeout: 30,
+    });
+
+    const service = new StatsService(
+      mockLogger,
+      mockClientManager,
+      cache,
+      sessionManager,
+      configLoader
+    );
+
+    const stats = await service.getStats({ detailLevel: 'full' });
+
+    // Summary
+    expect(stats.summary.serversConfigured).toBe(1);
+    expect(stats.summary.serversConnected).toBe(1);
+    expect(stats.summary.toolsTotal).toBe(2); // one excluded
+    expect(stats.summary.toolsCompressed).toBe(1);
+    expect(stats.summary.toolsUncompressed).toBe(1);
+    expect(stats.summary.coveragePercent).toBe(50);
+
+    // Per-server
+    expect(stats.servers).toHaveLength(1);
+    const server = stats.servers[0];
+    expect(server.name).toBe('serverA');
+    expect(server.toolsExcluded).toBe(1);
+    expect(server.toolsTotal).toBe(2);
+    expect(server.toolsCompressed).toBe(1);
+    expect(server.toolsUncompressed).toBe(1);
+    expect(server.coveragePercent).toBe(50);
+
+    // Cache/compression details
+    expect(stats.compression.cacheEntries).toBe(1);
+    expect(stats.compression.cacheFilePath).toBe('/tmp/cache.json');
+    expect(stats.compression.cacheSizeBytes).toBeGreaterThan(0);
+    expect(stats.compression.totalOriginalChars).toBeGreaterThan(0);
+    expect(stats.compression.totalCompressedChars).toBeGreaterThan(0);
+
+    // Sessions
+    expect(stats.sessions.activeSessions).toBe(1);
+    expect(stats.sessions.expandedToolsTotal).toBe(1);
+    expect(stats.sessions.sessions?.[0].sessionId).toBe(sessionId);
+
+    // Config echo
+    expect(stats.config.excludePatterns).toContain('serverA__skip_*');
+    expect(stats.config.noCompressPatterns).toContain('serverA__no_compress_*');
+  });
+
+  it('throws a clear error for unknown servers', async () => {
+    mockClientManager.getConnectedClients.mockReturnValue([]);
+    mockClientManager.getServerStatuses.mockReturnValue([]);
+
+    const service = new StatsService(
+      mockLogger,
+      mockClientManager,
+      cache,
+      sessionManager,
+      () => ({ servers: [], excludePatterns: [], noCompressPatterns: [] })
+    );
+
+    await expect(service.getStats({ serverName: 'missing' })).rejects.toThrow(
+      "Server 'missing' is not configured or not initialized"
+    );
+  });
+
+  it('keeps disconnected servers in the report with errors noted', async () => {
+    mockClientManager.getConnectedClients.mockReturnValue([]);
+    mockClientManager.getServerStatuses.mockReturnValue([
+      { name: 'offline', connected: false, lastError: 'Connection failed' } as any,
+    ]);
+
+    const service = new StatsService(
+      mockLogger,
+      mockClientManager,
+      cache,
+      sessionManager,
+      () => ({ servers: [], excludePatterns: [], noCompressPatterns: [] })
+    );
+
+    const stats = await service.getStats();
+
+    expect(stats.servers).toHaveLength(1);
+    expect(stats.servers[0].connected).toBe(false);
+    expect(stats.servers[0].error).toBe('Connection failed');
+    expect(stats.summary.serversWithErrors).toBe(1);
+  });
+});


### PR DESCRIPTION
# Description
Add a stats management tool (`mcp-compression-proxy__stats`) that returns JSON coverage/cache/session/server metrics with optional server filter and summary/full detail. Adds stats plumbing, cache metrics, docs, and tests. Fixes #14.

## Type of Change
- [x] New feature
- [x] Documentation update
- [x] Test improvements

## How Has This Been Tested?
- [x] Unit tests (`npm run test:unit -- stats-service.test.ts --runInBand`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used conventional commit messages